### PR TITLE
Enhancing MediatorMap#mapView to handle injection of the view as multiple classes

### DIFF
--- a/src/org/robotlegs/base/MediatorMap.as
+++ b/src/org/robotlegs/base/MediatorMap.as
@@ -90,7 +90,7 @@ package org.robotlegs.base
 		/**
 		 * @inheritDoc
 		 */
-		public function mapView(viewClassOrName:*, mediatorClass:Class, injectViewAs:Class = null, autoCreate:Boolean = true, autoRemove:Boolean = true):void
+		public function mapView(viewClassOrName:*, mediatorClass:Class, injectViewAs:* = null, autoCreate:Boolean = true, autoRemove:Boolean = true):void
 		{
 			var viewClassName:String = reflector.getFQCN(viewClassOrName);
 			if (mappingConfigByViewClassName[viewClassName] != null)
@@ -107,11 +107,18 @@ package org.robotlegs.base
 			config.autoRemove = autoRemove;
 			if (injectViewAs)
 			{
-				config.typedViewClass = injectViewAs;
+				if (injectViewAs is Array)
+				{
+					config.typedViewClasses = (injectViewAs as Array).concat();
+				}
+				else if (injectViewAs is Class)
+				{
+					config.typedViewClasses = [injectViewAs];
+				}
 			}
 			else if (viewClassOrName is Class)
 			{
-				config.typedViewClass = viewClassOrName;
+				config.typedViewClasses = [viewClassOrName];
 			}
 			mappingConfigByViewClassName[viewClassName] = config;
 			if (autoCreate && contextView && (viewClassName == getQualifiedClassName(contextView) ))
@@ -142,9 +149,13 @@ package org.robotlegs.base
 				var config:MappingConfig = mappingConfigByViewClassName[viewClassName];
 				if (config)
 				{
-					injector.mapValue(config.typedViewClass, viewComponent);
+					for each (var claxx:Class in config.typedViewClasses) {
+						injector.mapValue(claxx, viewComponent);
+					}
 					mediator = injector.instantiate(config.mediatorClass);
-					injector.unmap(config.typedViewClass);
+					for each (var clazz:Class in config.typedViewClasses) {
+						injector.unmap(clazz);
+					}
 					registerMediator(viewComponent, mediator);
 				}
 			}
@@ -303,7 +314,7 @@ package org.robotlegs.base
 class MappingConfig
 {
 	public var mediatorClass:Class;
-	public var typedViewClass:Class;
+	public var typedViewClasses:Array;
 	public var autoCreate:Boolean;
 	public var autoRemove:Boolean;
 }

--- a/src/org/robotlegs/core/IMediatorMap.as
+++ b/src/org/robotlegs/core/IMediatorMap.as
@@ -20,11 +20,11 @@ package org.robotlegs.core
 		 *
 		 * @param viewClassOrName The concrete view Class or Fully Qualified Class Name
 		 * @param mediatorClass The <code>IMediator</code> Class
-		 * @param injectViewAs The explicit view Interface or Class that the mediator depends on
+		 * @param injectViewAs The explicit view Interface or Class that the mediator depends on.  Also accepts an Array of Interface of Class.
 		 * @param autoCreate Automatically construct and register an instance of Class <code>mediatorClass</code> when an instance of Class <code>viewClass</code> is detected
 		 * @param autoRemove Automatically remove an instance of Class <code>mediatorClass</code> when it's <code>viewClass</code> leaves the ancestory of the context view
 		 */
-		function mapView(viewClassOrName:*, mediatorClass:Class, injectViewAs:Class = null, autoCreate:Boolean = true, autoRemove:Boolean = true):void;
+		function mapView(viewClassOrName:*, mediatorClass:Class, injectViewAs:* = null, autoCreate:Boolean = true, autoRemove:Boolean = true):void;
 		
 		/**
 		 * Unmap a view Class

--- a/test/org/robotlegs/base/MediatorMapTests.as
+++ b/test/org/robotlegs/base/MediatorMapTests.as
@@ -27,7 +27,9 @@ package org.robotlegs.base
 	import org.robotlegs.mvcs.support.TestContextView;
 	import org.robotlegs.mvcs.support.TestContextViewMediator;
 	import org.robotlegs.mvcs.support.ViewComponent;
+	import org.robotlegs.mvcs.support.ViewComponentAdvanced;
 	import org.robotlegs.mvcs.support.ViewMediator;
+	import org.robotlegs.mvcs.support.ViewMediatorAdvanced;
 	
 	public class MediatorMapTests
 	{
@@ -84,6 +86,50 @@ package org.robotlegs.base
 			var mediator:IMediator = mediatorMap.createMediator(viewComponent);
 			Assert.assertNotNull('Mediator should have been created ', mediator);
 			Assert.assertTrue('Mediator should have been created for View Component', mediatorMap.hasMediatorForView(viewComponent));
+		}
+		
+		[Test]
+		public function mediatorIsMappedAndCreatedWithInjectViewAsClass():void {
+			mediatorMap.mapView(ViewComponent, ViewMediator, ViewComponent, false, false);
+			var viewComponent:ViewComponent = new ViewComponent();
+			contextView.addChild(viewComponent);
+			var mediator:IMediator = mediatorMap.createMediator(viewComponent);
+			var exactMediator:ViewMediator = mediator as ViewMediator;
+			Assert.assertNotNull('Mediator should have been created', mediator);
+			Assert.assertTrue('Mediator should have been created of the exact desired class', mediator is ViewMediator);
+			Assert.assertTrue('Mediator should have been created for View Component', mediatorMap.hasMediatorForView(viewComponent));
+			Assert.assertNotNull('View Component should have been injected into Mediator', exactMediator.view);
+			Assert.assertTrue('View Component injected should match the desired class type', exactMediator.view is ViewComponent);
+		}
+		
+		[Test]
+		public function mediatorIsMappedAndCreatedWithInjectViewAsArrayOfSameClass():void {
+			mediatorMap.mapView(ViewComponent, ViewMediator, [ViewComponent], false, false);
+			var viewComponent:ViewComponent = new ViewComponent();
+			contextView.addChild(viewComponent);
+			var mediator:IMediator = mediatorMap.createMediator(viewComponent);
+			var exactMediator:ViewMediator = mediator as ViewMediator;
+			Assert.assertNotNull('Mediator should have been created', mediator);
+			Assert.assertTrue('Mediator should have been created of the exact desired class', mediator is ViewMediator);
+			Assert.assertTrue('Mediator should have been created for View Component', mediatorMap.hasMediatorForView(viewComponent));
+			Assert.assertNotNull('View Component should have been injected into Mediator', exactMediator.view);
+			Assert.assertTrue('View Component injected should match the desired class type', exactMediator.view is ViewComponent);
+		}
+		
+		[Test]
+		public function mediatorIsMappedAndCreatedWithInjectViewAsArrayOfRelatedClass():void {
+			mediatorMap.mapView(ViewComponentAdvanced, ViewMediatorAdvanced, [ViewComponent, ViewComponentAdvanced], false, false);
+			var viewComponentAdvanced:ViewComponentAdvanced = new ViewComponentAdvanced();
+			contextView.addChild(viewComponentAdvanced);
+			var mediator:IMediator = mediatorMap.createMediator(viewComponentAdvanced);
+			var exactMediator:ViewMediatorAdvanced = mediator as ViewMediatorAdvanced;
+			Assert.assertNotNull('Mediator should have been created', mediator);
+			Assert.assertTrue('Mediator should have been created of the exact desired class', mediator is ViewMediatorAdvanced);
+			Assert.assertTrue('Mediator should have been created for View Component', mediatorMap.hasMediatorForView(viewComponentAdvanced));
+			Assert.assertNotNull('First Class in the "injectViewAs" array should have been injected into Mediator', exactMediator.view);
+			Assert.assertNotNull('Second Class in the "injectViewAs" array should have been injected into Mediator', exactMediator.viewAdvanced);
+			Assert.assertTrue('First Class injected via the "injectViewAs" array should match the desired class type', exactMediator.view is ViewComponent);
+			Assert.assertTrue('Second Class injected via the "injectViewAs" array should match the desired class type', exactMediator.viewAdvanced is ViewComponentAdvanced);
 		}
 		
 		

--- a/test/org/robotlegs/mvcs/support/ViewComponentAdvanced.as
+++ b/test/org/robotlegs/mvcs/support/ViewComponentAdvanced.as
@@ -1,0 +1,11 @@
+package org.robotlegs.mvcs.support
+{
+	public class ViewComponentAdvanced extends ViewComponent
+	{
+		public function ViewComponentAdvanced()
+		{
+			super();
+		}
+		
+	}
+}

--- a/test/org/robotlegs/mvcs/support/ViewMediatorAdvanced.as
+++ b/test/org/robotlegs/mvcs/support/ViewMediatorAdvanced.as
@@ -1,0 +1,14 @@
+package org.robotlegs.mvcs.support
+{
+	public class ViewMediatorAdvanced extends ViewMediator
+	{
+		[Inject]
+		public var viewAdvanced:ViewComponentAdvanced;
+		
+		public function ViewMediatorAdvanced()
+		{
+			super();
+		}
+		
+	}
+}

--- a/test/org/robotlegs/mvcs/xmlconfig/XmlMediatorMapTests.as
+++ b/test/org/robotlegs/mvcs/xmlconfig/XmlMediatorMapTests.as
@@ -28,6 +28,13 @@ package org.robotlegs.mvcs.xmlconfig
 					<field name='event'/>
 					<field name='testSuite'/>
 				</type>
+				<type name='org.robotlegs.mvcs.support::ViewMediator'>
+					<field name='view'/>
+				</type>
+				<type name='org.robotlegs.mvcs.support::ViewMediatorAdvanced'>
+					<field name='view'/>
+					<field name='viewAdvanced'/>
+				</type>
 			</types>;
 		
 		[Before(ui)]


### PR DESCRIPTION
I propose a simple modification to IMediatorMap and MediatorMap to allow the mapping of a view component to multiple injection points in a mediator.  The rational for this modification is [discussed at greater length](http://knowledge.robotlegs.org/discussions/problems/165-mediators-and-inheritance-maximizing-code-reuse-minimizing-hacky-casting) in the robotlegs knowledge forum. 

The central API change required is backwards-compatible with previous code, but does change the signature of the IMediatorMap#mapView function.  The injectViewAs parameter is changed from expecting a Class to expecting a Class or an Array of Class objects. 
Old: 
    function mapView(viewClassOrName:*, mediatorClass:Class, injectViewAs:Class = null, autoCreate:Boolean = true, autoRemove:Boolean = true):void;

Proposed: 
    function mapView(viewClassOrName:_, mediatorClass:Class, injectViewAs:_ = null, autoCreate:Boolean = true, autoRemove:Boolean = true):void;
