### PR TITLE
Inject the "injector:IInjector" into "org.robotlegs.mvcs.Mediator" as default property.

### DIFF
--- a/src/org/robotlegs/mvcs/Mediator.as
+++ b/src/org/robotlegs/mvcs/Mediator.as
@@ -14,6 +14,7 @@ package org.robotlegs.mvcs
 	import org.robotlegs.base.EventMap;
 	import org.robotlegs.base.MediatorBase;
 	import org.robotlegs.core.IEventMap;
+	import org.robotlegs.core.IInjector;
 	import org.robotlegs.core.IMediatorMap;
 	
 	/**
@@ -27,6 +28,9 @@ package org.robotlegs.mvcs
 		[Inject]
 		public var mediatorMap:IMediatorMap;
 		
+		[Inject]
+		public var injector:IInjector;
+
 		/**
 		 * @private
 		 */


### PR DESCRIPTION
In some case it's seems not enough only have the injector functionality appear at the boot-up time of Mediator, there're  some case like map/get class/value may occurred at the certain time in Mediator besides starts up, I've searched the knowledge forum, and it's shows in several code samples with this trick too, thought this would be help in some way.
