### PR TITLE
Explicit ContextView configuration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,12 +26,11 @@ Plain ActionScript:
     _context = new Context()
         .extend(MVCSBundle)
         .configure(MyAppConfig, SomeOtherConfig)
-        .configure(this);
+        .configure(new ContextView(this));
 
-Note: We pass the instance "this" through to the context. It will be used as the "contextView" which is required by many of the view related extensions. It must be installed after the bundle or it won't be processed. Also, it should be added as the final configuration as it may trigger context initialization.
+Note: We pass the instance "this" through as the "contextView" which is required by many of the view related extensions. It must be installed after the bundle or it won't be processed. Also, it should be added as the final configuration as it may trigger context initialization.
 
 Note: You must hold on to the context instance or it will be garbage collected.
-
 
 
 Flex:

--- a/src/robotlegs/bender/bundles/shared/configs/ContextViewListenerConfig.as
+++ b/src/robotlegs/bender/bundles/shared/configs/ContextViewListenerConfig.as
@@ -7,12 +7,14 @@
 
 package robotlegs.bender.bundles.shared.configs
 {
-	import flash.display.DisplayObjectContainer;
+	import robotlegs.bender.extensions.contextView.ContextView;
 	import robotlegs.bender.extensions.viewManager.api.IViewManager;
 
 	/**
-	 * This simple configuration adds the mapped DisplayObjectContainer ("contextView")
-	 * to the viewManager.
+	 * This configuration file adds the ContextView to the viewManager.
+	 *
+	 * It requires the ViewManagerExtension, ContextViewExtension
+	 * and a ContextView have been installed.
 	 */
 	public class ContextViewListenerConfig
 	{
@@ -22,7 +24,7 @@ package robotlegs.bender.bundles.shared.configs
 		/*============================================================================*/
 
 		[Inject]
-		public var contextView:DisplayObjectContainer;
+		public var contextView:ContextView;
 
 		[Inject]
 		public var viewManager:IViewManager;
@@ -34,7 +36,7 @@ package robotlegs.bender.bundles.shared.configs
 		[PostConstruct]
 		public function init():void
 		{
-			viewManager.addContainer(contextView);
+			viewManager.addContainer(contextView.view);
 		}
 	}
 }

--- a/src/robotlegs/bender/extensions/contextView/ContextView.as
+++ b/src/robotlegs/bender/extensions/contextView/ContextView.as
@@ -1,0 +1,35 @@
+//------------------------------------------------------------------------------
+//  Copyright (c) 2012 the original author or authors. All Rights Reserved. 
+// 
+//  NOTICE: You are permitted to use, modify, and distribute this file 
+//  in accordance with the terms of the license agreement accompanying it. 
+//------------------------------------------------------------------------------
+
+package robotlegs.bender.extensions.contextView
+{
+	import flash.display.DisplayObjectContainer;
+
+	public class ContextView
+	{
+
+		/*============================================================================*/
+		/* Public Properties                                                          */
+		/*============================================================================*/
+
+		private var _view:DisplayObjectContainer;
+
+		public function get view():DisplayObjectContainer
+		{
+			return _view;
+		}
+
+		/*============================================================================*/
+		/* Constructor                                                                */
+		/*============================================================================*/
+
+		public function ContextView(view:DisplayObjectContainer)
+		{
+			_view = view;
+		}
+	}
+}

--- a/src/robotlegs/bender/extensions/contextView/ContextViewExtension.as
+++ b/src/robotlegs/bender/extensions/contextView/ContextViewExtension.as
@@ -7,7 +7,6 @@
 
 package robotlegs.bender.extensions.contextView
 {
-	import flash.display.DisplayObjectContainer;
 	import org.hamcrest.object.instanceOf;
 	import org.swiftsuspenders.Injector;
 	import robotlegs.bender.framework.api.IContext;
@@ -16,8 +15,8 @@ package robotlegs.bender.extensions.contextView
 	import robotlegs.bender.framework.impl.UID;
 
 	/**
-	 * <p>This Extension waits for a DisplayObjectContainer to be added as a configuration
-	 * and maps that container into the context's injector.</p>
+	 * <p>This Extension waits for a ContextView to be added as a configuration
+	 * and maps it into the context's injector.</p>
 	 *
 	 * <p>It should be installed before context initialization.</p>
 	 */
@@ -38,13 +37,12 @@ package robotlegs.bender.extensions.contextView
 		/* Public Functions                                                           */
 		/*============================================================================*/
 
-		// todo: accept contextView via constructor and use that if provided
-
 		public function extend(context:IContext):void
 		{
 			_injector = context.injector;
 			_logger = context.getLogger(this);
-			context.addConfigHandler(instanceOf(DisplayObjectContainer), handleContextView);
+			context.addConfigHandler(instanceOf(ContextView), handleContextView);
+			context.lifecycle.beforeInitializing(beforeInitializing);
 		}
 
 		public function toString():String
@@ -56,16 +54,24 @@ package robotlegs.bender.extensions.contextView
 		/* Private Functions                                                          */
 		/*============================================================================*/
 
-		private function handleContextView(view:DisplayObjectContainer):void
+		private function handleContextView(contextView:ContextView):void
 		{
-			if (_injector.hasDirectMapping(DisplayObjectContainer))
+			if (_injector.hasDirectMapping(ContextView))
 			{
-				_logger.warn('A contextView has already been mapped, ignoring {0}', [view]);
+				_logger.warn('A contextView has already been installed, ignoring {0}', [contextView.view]);
 			}
 			else
 			{
-				_logger.debug("Mapping {0} as contextView", [view]);
-				_injector.map(DisplayObjectContainer).toValue(view);
+				_logger.debug("Mapping {0} as contextView", [contextView.view]);
+				_injector.map(ContextView).toValue(contextView);
+			}
+		}
+
+		private function beforeInitializing():void
+		{
+			if (!_injector.hasDirectMapping(ContextView))
+			{
+				throw( new Error("A ContextView must be installed if you install the ContextViewExtension."));
 			}
 		}
 	}

--- a/src/robotlegs/bender/extensions/contextView/readme.md
+++ b/src/robotlegs/bender/extensions/contextView/readme.md
@@ -1,6 +1,6 @@
 # ContextView
 
-The Context View Extension adds a configuration processor to the context that consumes a DisplayObjectContainer and maps it into the context. Many extensions require a DisplayObjectContainer to be present in order to function correctly.
+The Context View Extension adds a configuration processor to the context that consumes a ContextView object and maps the provided view as a DisplayObjectContainer into the context. Many extensions require a DisplayObjectContainer to be present in order to function correctly.
 
 ## Installation
 
@@ -8,8 +8,8 @@ The Context View Extension adds a configuration processor to the context that co
 
     _context = new Context()
         .extend(ContextViewExtension)
-        .configure(this);
+        .configure(new ContextView(this));
 
-Note: The extension must be installed before a DisplayObjectContainer is provided or the DisplayObjectContainer will not be processed.
+Note: The extension must be installed before the ContextView is provided or it will not be processed.
 
-In the example above we provide the instance "this" to use as the Context View. We assume that "this" is a valid DisplayObjectContainer.
+In the example above we provide the instance "this" to use as the view. We assume that "this" is a valid DisplayObjectContainer.

--- a/src/robotlegs/bender/extensions/stageSync/StageSyncExtension.as
+++ b/src/robotlegs/bender/extensions/stageSync/StageSyncExtension.as
@@ -10,14 +10,16 @@ package robotlegs.bender.extensions.stageSync
 	import flash.display.DisplayObjectContainer;
 	import flash.events.Event;
 	import org.hamcrest.object.instanceOf;
+
+	import robotlegs.bender.extensions.contextView.ContextView;
 	import robotlegs.bender.framework.api.IContext;
 	import robotlegs.bender.framework.api.IExtension;
 	import robotlegs.bender.framework.api.ILogger;
 	import robotlegs.bender.framework.impl.UID;
 
 	/**
-	 * <p>This Extension waits for a DisplayObjectContainer to be added as a configuration,
-	 * and initializes and destroys the context based on that container's stage presence.</p>
+	 * <p>This Extension waits for a ContextView to be added as a configuration,
+	 * and initializes and destroys the context based on the contextView's stage presence.</p>
 	 *
 	 * <p>It should be installed before context initialization.</p>
 	 */
@@ -45,7 +47,7 @@ package robotlegs.bender.extensions.stageSync
 			_context = context;
 			_logger = context.getLogger(this);
 			_context.addConfigHandler(
-				instanceOf(DisplayObjectContainer),
+				instanceOf(ContextView),
 				handleContextView);
 		}
 
@@ -58,14 +60,14 @@ package robotlegs.bender.extensions.stageSync
 		/* Private Functions                                                          */
 		/*============================================================================*/
 
-		private function handleContextView(view:DisplayObjectContainer):void
+		private function handleContextView(contextView:ContextView):void
 		{
 			if (_contextView)
 			{
-				_logger.warn('A contextView has already been set, ignoring {0}', [view]);
+				_logger.warn('A contextView has already been installed, ignoring {0}', [contextView.view]);
 				return;
 			}
-			_contextView = view;
+			_contextView = contextView.view;
 			if (_contextView.stage)
 			{
 				initializeContext();

--- a/src/robotlegs/bender/extensions/viewManager/impl/ManualStageObserver.as
+++ b/src/robotlegs/bender/extensions/viewManager/impl/ManualStageObserver.as
@@ -73,7 +73,6 @@ package robotlegs.bender.extensions.viewManager.impl
 
 		private function removeContainerListener(container:DisplayObjectContainer):void
 		{
-			// Release the container listener
 			container.removeEventListener(ConfigureViewEvent.CONFIGURE_VIEW, onConfigureView);
 		}
 

--- a/src/robotlegs/bender/framework/readme-context.md
+++ b/src/robotlegs/bender/framework/readme-context.md
@@ -10,7 +10,7 @@ To create a context simply instantiate a new Context and provide some configurat
         .extend(MVCSBundle)
         .configure(
             MyModuleConfig,
-            view
+            new ContextView(view)
         );
 
 Note: you must hold on to that context reference. Failing to do so will result in the context instance being garbage collected.

--- a/src/robotlegs/bender/mxml/ContextBuilderTag.as
+++ b/src/robotlegs/bender/mxml/ContextBuilderTag.as
@@ -12,6 +12,8 @@ package robotlegs.bender.mxml
 	import mx.core.IMXMLObject;
 	import org.swiftsuspenders.reflection.DescribeTypeReflector;
 	import org.swiftsuspenders.reflection.Reflector;
+
+	import robotlegs.bender.extensions.contextView.ContextView;
 	import robotlegs.bender.framework.api.IContext;
 	import robotlegs.bender.framework.api.IExtension;
 	import robotlegs.bender.framework.impl.Context;
@@ -83,7 +85,7 @@ package robotlegs.bender.mxml
 					: _context.configure(config);
 			}
 
-			_contextView && _context.configure(_contextView);
+			_contextView && _context.configure(new ContextView(_contextView));
 			_configs.length = 0;
 		}
 

--- a/test/robotlegs/bender/extensions/contextView/ContextViewExtensionTest.as
+++ b/test/robotlegs/bender/extensions/contextView/ContextViewExtensionTest.as
@@ -23,7 +23,7 @@ package robotlegs.bender.extensions.contextView
 
 		private var context:IContext;
 
-		private var contextView:DisplayObjectContainer;
+		private var view:DisplayObjectContainer;
 
 		/*============================================================================*/
 		/* Test Setup and Teardown                                                    */
@@ -33,7 +33,7 @@ package robotlegs.bender.extensions.contextView
 		public function before():void
 		{
 			context = new Context();
-			contextView = new Canvas();
+			view = new Canvas();
 		}
 
 		/*============================================================================*/
@@ -41,28 +41,35 @@ package robotlegs.bender.extensions.contextView
 		/*============================================================================*/
 
 		[Test]
-		public function displayObjectContainer_is_mapped_into_injector_as_contextView():void
+		public function contextView_is_mapped():void
 		{
-			var actual:Object = null;
-			context.extend(ContextViewExtension).configure(contextView);
+			var actual:ContextView = null;
+			context.extend(ContextViewExtension).configure(new ContextView(view));
 			context.lifecycle.whenInitializing(function():void {
-				actual = context.injector.getInstance(DisplayObjectContainer);
+				actual = context.injector.getInstance(ContextView);
 			});
 			context.lifecycle.initialize();
-			assertThat(actual, equalTo(contextView));
+			assertThat(actual.view, equalTo(view));
 		}
 
 		[Test]
 		public function second_displayObjectContainer_is_ignored():void
 		{
-			var actual:Object = null;
+			var actual:ContextView = null;
 			const secondView:DisplayObjectContainer = new Canvas();
-			context.extend(ContextViewExtension).configure(contextView, secondView);
+			context.extend(ContextViewExtension).configure(new ContextView(view), new ContextView(secondView));
 			context.lifecycle.whenInitializing(function():void {
-				actual = context.injector.getInstance(DisplayObjectContainer);
+				actual = context.injector.getInstance(ContextView);
 			});
 			context.lifecycle.initialize();
-			assertThat(actual, equalTo(contextView));
+			assertThat(actual.view, equalTo(view));
+		}
+
+		[Test(expects="Error")]
+		public function extension_throws_if_context_initialized_with_no_contextView():void
+		{
+			context.extend(ContextViewExtension);
+			context.lifecycle.initialize();
 		}
 	}
 }

--- a/test/robotlegs/bender/extensions/modularity/ModularityExtensionTest.as
+++ b/test/robotlegs/bender/extensions/modularity/ModularityExtensionTest.as
@@ -12,6 +12,8 @@ package robotlegs.bender.extensions.modularity
 	import org.fluint.uiImpersonation.UIImpersonator;
 	import org.hamcrest.core.not;
 	import org.hamcrest.object.equalTo;
+
+	import robotlegs.bender.extensions.contextView.ContextView;
 	import robotlegs.bender.extensions.contextView.ContextViewExtension;
 	import robotlegs.bender.extensions.stageSync.StageSyncExtension;
 	import robotlegs.bender.extensions.viewManager.ViewManagerExtension;
@@ -65,8 +67,8 @@ package robotlegs.bender.extensions.modularity
 		public function context_inherits_parent_injector():void
 		{
 			UIImpersonator.addChild(root);
-			parentContext.extend(ModularityExtension).configure(parentView);
-			childContext.extend(ModularityExtension).configure(childView);
+			parentContext.extend(ModularityExtension).configure(new ContextView(parentView));
+			childContext.extend(ModularityExtension).configure(new ContextView(childView));
 			root.addChild(parentView);
 			parentView.addChild(childView);
 			assertThat(childContext.injector.parentInjector, equalTo(parentContext.injector));
@@ -76,8 +78,8 @@ package robotlegs.bender.extensions.modularity
 		public function context_does_not_inherit_parent_injector_when_not_interested():void
 		{
 			UIImpersonator.addChild(root);
-			parentContext.extend(ModularityExtension).configure(parentView);
-			childContext.extend(new ModularityExtension(false)).configure(childView);
+			parentContext.extend(ModularityExtension).configure(new ContextView(parentView));
+			childContext.extend(new ModularityExtension(false)).configure(new ContextView(childView));
 			root.addChild(parentView);
 			parentView.addChild(childView);
 			assertThat(childContext.injector.parentInjector, not(parentContext.injector));
@@ -87,8 +89,8 @@ package robotlegs.bender.extensions.modularity
 		public function context_does_not_inherit_parent_injector_when_disallowed_by_parent():void
 		{
 			UIImpersonator.addChild(root);
-			parentContext.extend(new ModularityExtension(true, false)).configure(parentView);
-			childContext.extend(ModularityExtension).configure(childView);
+			parentContext.extend(new ModularityExtension(true, false)).configure(new ContextView(parentView));
+			childContext.extend(ModularityExtension).configure(new ContextView(childView));
 			root.addChild(parentView);
 			parentView.addChild(childView);
 			assertThat(childContext.injector.parentInjector, not(parentContext.injector));
@@ -101,7 +103,7 @@ package robotlegs.bender.extensions.modularity
 			childContext.lifecycle.initialize();
 		}
 
-		[Test]
+		[Test(async, ui)]
 		public function child_added_to_viewManager_inherits_injector():void
 		{
 			UIImpersonator.addChild(root);
@@ -110,7 +112,7 @@ package robotlegs.bender.extensions.modularity
 				ModularityExtension,
 				ViewManagerExtension,
 				StageSyncExtension)
-				.configure(parentView);
+				.configure(new ContextView(parentView));
 
 			const viewManager:IViewManager =
 				parentContext.injector.getInstance(IViewManager);
@@ -120,7 +122,7 @@ package robotlegs.bender.extensions.modularity
 				ContextViewExtension,
 				ModularityExtension,
 				StageSyncExtension)
-				.configure(childView);
+				.configure(new ContextView(childView));
 
 			root.addChild(parentView);
 			root.addChild(childView);

--- a/test/robotlegs/bender/extensions/stageSync/StageSyncExtensionTest.as
+++ b/test/robotlegs/bender/extensions/stageSync/StageSyncExtensionTest.as
@@ -15,6 +15,8 @@ package robotlegs.bender.extensions.stageSync
 	import org.fluint.uiImpersonation.UIImpersonator;
 	import org.hamcrest.object.isTrue;
 
+	import robotlegs.bender.extensions.contextView.ContextView;
+
 	import robotlegs.bender.framework.api.IContext;
 	import robotlegs.bender.framework.impl.Context;
 
@@ -47,7 +49,7 @@ package robotlegs.bender.extensions.stageSync
 		[Test]
 		public function adding_contextView_to_stage_initializes_context():void
 		{
-			context.extend(StageSyncExtension).configure(contextView);
+			context.extend(StageSyncExtension).configure(new ContextView(contextView));
 			UIImpersonator.addChild(contextView);
 			assertThat(context.lifecycle.initialized, isTrue());
 		}
@@ -56,14 +58,14 @@ package robotlegs.bender.extensions.stageSync
 		public function adding_contextView_that_is_already_on_stage_initializes_context():void
 		{
 			UIImpersonator.addChild(contextView);
-			context.extend(StageSyncExtension).configure(contextView);
+			context.extend(StageSyncExtension).configure(new ContextView(contextView));
 			assertThat(context.lifecycle.initialized, isTrue());
 		}
 
 		[Test]
 		public function removing_contextView_from_stage_destroys_context():void
 		{
-			context.extend(StageSyncExtension).configure(contextView);
+			context.extend(StageSyncExtension).configure(new ContextView(contextView));
 			UIImpersonator.addChild(contextView);
 			UIImpersonator.removeChild(contextView);
 			assertThat(context.lifecycle.destroyed, isTrue());

--- a/test/robotlegs/bender/framework/impl/ConfigManagerTest.as
+++ b/test/robotlegs/bender/framework/impl/ConfigManagerTest.as
@@ -161,8 +161,18 @@ package robotlegs.bender.framework.impl
 			context.initialize();
 			assertThat(actual, array(['listener1', 'listener2', 'config']));
 		}
+
+		[Test]
+		public function injector_allows_mappings_inside_PostConstruct():void
+		{
+			configManager.addConfig(MappingConfig);
+			configManager.addConfig(ChildConfig);
+			context.initialize();
+		}
 	}
 }
+
+import org.swiftsuspenders.Injector;
 
 import robotlegs.bender.framework.api.IConfig;
 
@@ -205,4 +215,23 @@ class TypedConfig implements IConfig
 	{
 		callback(this);
 	}
+}
+
+class MappingConfig
+{
+	[PostConstruct]
+	public function init(injector:Injector):void
+	{
+		injector.map(SomeSingleton).asSingleton();
+	}
+}
+
+class SomeSingleton
+{
+}
+
+class ChildConfig
+{
+	[Inject]
+	public var someSingleton:SomeSingleton
 }


### PR DESCRIPTION
Switches to explicit ContextView configuration. Maps the provided contextView as a ContextView instead of a DisplayObjectContainer.

Passing a view reference straight into the config manager was not clear and was a potential source of bugs for developers. Also, directly mapping the view into the Injector as a DisplayObjectContainer felt wrong.
