### PR TITLE
test command gets executed when mapped to the event whose command mappings are being processed 

### DIFF
--- a/test/robotlegs/bender/extensions/ExtensionsTestSuite.as
+++ b/test/robotlegs/bender/extensions/ExtensionsTestSuite.as
@@ -1,8 +1,8 @@
 //------------------------------------------------------------------------------
-//  Copyright (c) 2011 the original author or authors. All Rights Reserved. 
-// 
-//  NOTICE: You are permitted to use, modify, and distribute this file 
-//  in accordance with the terms of the license agreement accompanying it. 
+//  Copyright (c) 2011 the original author or authors. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
 //------------------------------------------------------------------------------
 
 package robotlegs.bender.extensions
@@ -62,7 +62,7 @@ package robotlegs.bender.extensions
 		public var stageSyncExtension:StageSyncExtensionTestSuite;
 
 		public var viewManagerExtension:ViewManagerExtensionTestSuite;
-			
+
 		public var viewProcessorMapExtension:ViewProcessorMapExtensionTestSuite;
 
 		public var vigilanceExtension:VigilanceExtensionTestSuite;

--- a/test/robotlegs/bender/extensions/messageCommandMap/MessageCommandMapExtensionTestSuite.as
+++ b/test/robotlegs/bender/extensions/messageCommandMap/MessageCommandMapExtensionTestSuite.as
@@ -1,8 +1,8 @@
 //------------------------------------------------------------------------------
-//  Copyright (c) 2011 the original author or authors. All Rights Reserved. 
-// 
-//  NOTICE: You are permitted to use, modify, and distribute this file 
-//  in accordance with the terms of the license agreement accompanying it. 
+//  Copyright (c) 2011 the original author or authors. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
 //------------------------------------------------------------------------------
 
 package robotlegs.bender.extensions.messageCommandMap


### PR DESCRIPTION
Just to be clear, the test fails when the command is mapped with `once(true)` but passes with `once(false)`

see robotlegs/robotlegs-framework#114
