### PR TITLE
Easy way to listen context dispatch

### DIFF
--- a/src/robotlegs/bender/bundles/mvcs/Mediator.as
+++ b/src/robotlegs/bender/bundles/mvcs/Mediator.as
@@ -59,6 +59,27 @@ package robotlegs.bender.bundles.mvcs
 			eventMap.unmapListeners();
 		}
 
+		/**
+		 * List the <code>Event</code> names this
+		 * <code>Mediator</code> is interested in being dispatched of.
+		 *
+		 * @return Array the list of <code>Event</code> names 
+		 */
+		public function listEventInterests():Array 
+		{
+			return [];
+		}
+
+		/**
+		 * Handle <code>Event</code>s.
+		 *
+		 * <P>
+		 * Typically this will be handled in a switch statement,
+		 * with one 'case' entry per <code>Event</code>
+		 * the <code>Mediator</code> is interested in.
+		 */
+		public function handleEvent(event:Event):void {}
+
 		/*============================================================================*/
 		/* Protected Functions                                                        */
 		/*============================================================================*/

--- a/src/robotlegs/bender/extensions/mediatorMap/impl/DefaultMediatorManager.as
+++ b/src/robotlegs/bender/extensions/mediatorMap/impl/DefaultMediatorManager.as
@@ -75,6 +75,15 @@ package robotlegs.bender.extensions.mediatorMap.impl
 			const mediator:Object = event.mediator;
 			const displayObject:DisplayObject = event.mediatedItem as DisplayObject;
 
+			var interests:Array = mediator.listEventInterests();
+
+			if(interests && interests.length > 0)
+			{
+				for each(var eventType:String in interests)
+					mediator.eventMap.mapListener(
+						mediator.eventDispatcher, eventType, mediator.handleEvent);
+			}
+
 			if (!displayObject)
 			{
 				// Non-display-object was added, initialize and exit


### PR DESCRIPTION
``` as3
override public function listEventInterests():Array
{
  return [FileEvent.DOWNLOADING, FileEvent.UPLOADING];
}

override public function handleEvent(event:Event):void
{
  switch(event.type)
  {
    case FileEvent.DOWNLOADING:
      // do something
      break;
    case FileEvent.UPLOADING:
      // do something
      break;
  }
}
```

Instead of

``` as3
override public function initialize():void
{
  addContextListener(FileEvent.DOWNLOADING, _onFile_DownloadingHandler);
  addContextListener(FileEvent.UPLOADING, _onFile_UploadingHandler);
  // a lots of addContextListener 
}
```

Same as `PureMVC` event instead notification.
It's just idea without unit testing.
What do you think?
