### PR TITLE
Update guardsApprove.as

### DIFF
--- a/src/robotlegs/bender/framework/impl/guardsApprove.as
+++ b/src/robotlegs/bender/framework/impl/guardsApprove.as
@@ -46,6 +46,10 @@ package robotlegs.bender.framework.impl
 					? injector.instantiateUnmapped(guard as Class)
 					: new (guard as Class);
 			}
+			else
+			{
+				injector.injectInto(guard);
+			}
 			if (guard.approve() == false)
 				return false;
 		}

--- a/src/robotlegs/bender/framework/impl/guardsApprove.as
+++ b/src/robotlegs/bender/framework/impl/guardsApprove.as
@@ -40,7 +40,7 @@ package robotlegs.bender.framework.impl
 					continue;
 				return false;
 			}
-			if (guard is Class)
+			else if (guard is Class)
 			{
 				guard = injector
 					? injector.instantiateUnmapped(guard as Class)


### PR DESCRIPTION
in this way, we can pass complex guard objects, for example:

withGuards(Guards.or(SomeGuard, Guards.not(SomeAnotherGuard)));
