### PR TITLE
Adding Travis-CI to Robotlegs V1.0 branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /bin/*
 docs/*
 obj/*
+target/*
 
 .actionScriptProperties
 .flexProperties

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: objective-c
+
+before_script:
+  # set the JAVA_HOME which is not set by default for OSX Travis-CI workers
+  - export "JAVA_HOME=`/usr/libexec/java_home`"
+  # Download and install a specific Flash Player from the Adobe Archives:
+  # http://helpx.adobe.com/flash-player/kb/archived-flash-player-versions.html
+  - sh getFpFromArchive.sh 'http://download.macromedia.com/pub/flashplayer/installers/archive/fp_11.7.700.225_archive.zip'
+  # Install Local Modules Script:
+  - sh maven-runonce.sh
+
+script: mvn clean install -s settings.xml -DflashPlayer.command=Flash\ Player\ Debugger.app/Contents/MacOS/Flash\ Player\ Debugger

--- a/Maven-README.md
+++ b/Maven-README.md
@@ -1,0 +1,44 @@
+Maven usage
+=====
+
+Installation
+------
+
+__Step 1: Install Maven 3.0.3+__
+
+[Download from here](http://maven.apache.org/download.html)
+
+* OS X (Alternative)
+
+		brew install maven
+
+__Step 2: Ensure maven binaries are on your PATH (ie. you can run `mvn` from anywhere)__
+
+Follow the installation instructions from [here](http://maven.apache.org/download.html#Installation).
+
+__Step 3: CD to the robotlegs root (where the POM.xml lives)__
+
+__Step 4: Install the third party dependencies into your local repository__
+
+* In OS X
+
+		bash -x maven-runonce.sh
+
+* In Windows 
+	
+		maven-runonce.bat
+
+>Note: we do this because unlike Ant, Maven requires all dependencies live within a repository somewhere. Because none of these dependencies are hosted externally on a remote repository, we need to install them locally into the repository. Going forward, the hope is that many of these dependencies will live in Maven Central, negating the need to install them locally. JM.
+
+	
+To build
+-----
+In order to build Robotlegs from source, run the following command in the Robotlegs root folder.
+
+	mvn clean install -s settings.xml -DflashPlayer.command=[Path To Flash Player]
+	
+Alternative to supplying settings
+-----
+If you would rather not supply `-s settings.xml` for every build, you can add the repository information from settings.xml into your local repository. Alternatively, you can simply copy the robotlegs settings.xml to `~/.m2/settings.xml` where ~ is your user directory (`\Users\username` in Win7+)
+ 
+> __Why do we need the settings file?__ While Flexmojos lives within Maven Central, its dependencies (such as the Flex compiler) and flash project dependencies (such as framework SDKs) do NOT. They live within the flexgroup branch off (sonatype)[http://repository.sonatype.org/content/groups/flexgroup/].   

--- a/README.textile
+++ b/README.textile
@@ -1,4 +1,5 @@
 h2. Robotlegs: A pure AS3 micro-architecture for Flash and Flex
+!https://travis-ci.org/haysclark/robotlegs-framework.svg?branch=version1!:https://github.com/haysclark/robotlegs-framework/tree/version1
 
 Robotlegs is a lightweight AS3 MVCS micro-architecture. Robotlegs was created to provide a small, loosely coupled application framework that is easy to test.
 

--- a/getFpFromArchive.sh
+++ b/getFpFromArchive.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+#
+# Get FlashPlayer Form Archive 1.0, 2014
+#
+# Script downloads a Flash Archive zip, unzips the archive, located the needed
+# Mac OS Debug Flash Player, unzips that file and cleans up all but the Flash
+# Player folder.
+#
+# Find specific Flash Player from the Adobe Archives:
+# http://helpx.adobe.com/flash-player/kb/archived-flash-player-versions.html
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy of 
+# this software and associated documentation files (the "Software"), to deal in 
+# the Software without restriction, including without limitation the rights to 
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
+# of the Software, and to permit persons to whom the Software is furnished to do 
+# so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all 
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+# SOFTWARE.
+# 
+# Tested on OSX (10.9)
+# 
+# Copyright (c) 2014 Hays Clark
+#
+
+FP_ARCHIVE_PATH="fp_archive"
+FP_ARCHIVE_ZIP="fp_archive.zip"
+EXPECTED_ARG="<FlashPlayer Archile Url>"
+VERSION="1.0"
+
+if [ "$#" -gt 1 ]; then
+  echo "Too many arguments."
+  echo "Usage: $0 ${EXPECTED_ARG}"
+  exit 1
+fi
+
+if [ "$1" = "" ]; then
+	echo "Missing required argument."
+	echo "Usage: $0 ${EXPECTED_ARG}"
+	exit 1
+fi
+
+echo "[INFO] ------------------------------------------------------------------------"
+echo "[INFO] Get FlashPlayer From Archive, ${VERSION}"
+echo "[INFO] ------------------------------------------------------------------------"
+
+# Download the archive
+FP_ZIP_ARCHIVE_URL=$1
+echo "[INFO] Downloading: ${FP_ZIP_ARCHIVE_URL}"
+curl -L ${FP_ZIP_ARCHIVE_URL} >> ${FP_ARCHIVE_ZIP}
+
+# Unzip archive
+echo "[INFO] Unzipping to: ${FP_ARCHIVE_PATH}"
+unzip ${FP_ARCHIVE_ZIP} -d ${FP_ARCHIVE_PATH}
+
+# locate the mac_sa_debug.app.zip file and ignore any .* files
+# these seem to be inconsistent, "*mac_sa_debug.app.zip" and
+# "*mac_sa_debug.zip" have been notedr,
+MAC_SA_DEBUG_APP_ZIP=`find . -type f \( -iname "*mac_sa_debug*.zip" ! -iname ".*" \)`
+if [ "${MAC_SA_DEBUG_APP_ZIP}" = "" ]; then
+	echo "[ERROR] Can not find required Mac SA Debug Player ZIP."
+	exit 1
+fi
+echo "[INFO] Found Mac SA Debug Player Zip: ${MAC_SA_DEBUG_APP_ZIP}"
+
+# Unzip mac_sa_debug.app.zip
+echo "[INFO] Unzipping player"
+unzip ${MAC_SA_DEBUG_APP_ZIP}
+
+# cleanup
+echo "[INFO] cleaning up temp files."
+rm ${FP_ARCHIVE_ZIP}
+rm -r ${FP_ARCHIVE_PATH}
+
+echo "[INFO] ------------------------------------------------------------------------"
+echo "[INFO] Flash Player Downloaded and Unzip Success"
+echo "[INFO] ------------------------------------------------------------------------"
+
+# done
+exit 0

--- a/maven-runonce.bat
+++ b/maven-runonce.bat
@@ -1,0 +1,1 @@
+call mvn -s settings.xml install:install-file -Dfile=build/libs/SwiftSuspenders-v1.6.0.swc -DartifactId=swiftsuspenders -DgroupId=org.swiftsuspenders -Dversion=1.6.0 -Dpackaging=swc

--- a/maven-runonce.sh
+++ b/maven-runonce.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+mvn -s settings.xml install:install-file -Dfile=build/libs/SwiftSuspenders-v1.6.0.swc -DartifactId=swiftsuspenders -DgroupId=org.swiftsuspenders -Dversion=1.6.0 -Dpackaging=swc

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.robotlegs</groupId>
     <artifactId>robotlegs-framework</artifactId>
-    <version>1.3.0</version>
+    <version>1.5.3</version>
 	<packaging>swc</packaging>
     <name>Robotlegs Framework</name>
     <description>Robotlegs is a pure AS3 micro-architecture (framework) with a light footprint and limited scope. Simply put, Robotlegs is there to help you wire your objects together. It provides the glue that your application needs to easily function in a decoupled way. Through the use of automated metadata based dependency injection Robotlegs removes boilerplate code in an application. By promoting loose coupling and avoiding the use of Singletons and statics in the framework Robotlegs can help you write code that is highly testable.</description>
@@ -46,10 +46,15 @@
             <email>codecraig@gmail.com</email>
             <url>http://digitalchickenscratch.com/</url>
         </contributor>
+        <contributor>
+            <name>Hays Clark</name>
+            <email>hays.clark@gmail.com</email>
+            <url>http://omita.com/</url>
+        </contributor>
     </contributors>
 
     <scm>
-        <url>http://github.com/robotlegs/robotlegs-framework/tree/master</url>
+        <url>http://github.com/robotlegs/robotlegs-framework/tree/version1</url>
         <connection>git://github.com/robotlegs/robotlegs-framework.git</connection>
     </scm>
 
@@ -79,7 +84,7 @@
 		<flashplayer.version>10.0.0</flashplayer.version>
         <flexmojos.compiler.version>3.5.0</flexmojos.compiler.version>
         <flexunit.version>4.0-beta-2</flexunit.version>
-        <swiftsuspenders.version>1.0.1</swiftsuspenders.version>
+        <swiftsuspenders.version>1.6.0</swiftsuspenders.version>
     </properties>
 
     <prerequisites>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+	
+	<profiles>
+		<profile>
+			<id>flexgroup-on-sonatype</id>
+			<repositories>
+				<repository>
+					<id>Sonatype Flex Group</id>
+					<url>http://repository.sonatype.org/content/groups/flexgroup/</url>
+				</repository>
+			</repositories>
+			<pluginRepositories>
+				<pluginRepository>
+					<id>Sonatype Flex Group</id>
+					<url>http://repository.sonatype.org/content/groups/flexgroup/</url>
+				</pluginRepository>
+			</pluginRepositories>
+		</profile>
+	</profiles>
+	
+	<!-- NOTE: this will deactivate any "activeByDefault" profiles in the project POM -->
+	<activeProfiles>
+	    <activeProfile>flexgroup-on-sonatype</activeProfile>
+	  </activeProfiles>
+</settings>


### PR DESCRIPTION
I wanted to share some of my recent work on this project:
[Running AS3 Projects With Travis-CI](https://github.com/Larusso/travis-CI-actionscript-demo), with the RBL community.  This change really doesn't do much more then run the existing Maven build process on Travis-CI so that we can have this cute icon in the README.

[![Build Status](https://travis-ci.org/haysclark/robotlegs-framework.svg?branch=version1)](https://travis-ci.org/haysclark/robotlegs-framework)

This pull request is just updating the 'version1' branch.  If people like the minor change I can add this work too the other branches, or any other author could make the change.  Someone with Admin right to the 'robotlegs' GitHub user account will need to [create a Travis-CI account](https://travis-ci.org/) and then 'enable' the **robotlegs-framework** repo.

There is also a nice Travis-CI zsh plug-in.  Please let me know if you have any feedback.
