### PR TITLE
Documentation updates

### DIFF
--- a/src/robotlegs/bender/extensions/viewManager/StageCrawlerExtension.md
+++ b/src/robotlegs/bender/extensions/viewManager/StageCrawlerExtension.md
@@ -5,7 +5,7 @@
 The Stage Crawler Extension scans and handles all views in the containers or contextview after context initialization.
 This enables us to handle the views that might already be on the stage before initialization which would otherwise not be processed (or mediated).
 
-It is reliant on either a IViewManager or a ContextView upon initializtion.
+It is reliant on either a IViewManager or a ContextView upon initialization.
 
 ## How to Install
 

--- a/src/robotlegs/bender/extensions/viewManager/StageObserverExtension.md
+++ b/src/robotlegs/bender/extensions/viewManager/StageObserverExtension.md
@@ -4,9 +4,9 @@
 
 The Stage Observer Extension adds a single instance. Which listens for everything that is Event.ADDED_TO_STAGE on all root containers in the Container Registry, and then processes the view for you.
 
-It will listen for removal and new root containers and adjust it's listeners appropriatley.
+It will listen for removal and new root containers and adjust it's listeners appropriately.
 
-The Stage Observer has a static instance stored in the extension but will destory/cleanup when all context's have been destroyed.
+The Stage Observer has a static instance stored in the extension but will destroy/cleanup when all context's have been destroyed.
 
 ## How to Install
 

--- a/src/robotlegs/bender/extensions/viewProcessorMap/readme.md
+++ b/src/robotlegs/bender/extensions/viewProcessorMap/readme.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The view processor map provides automagic processing of mapped views landing on the stage and manual processing where preferred.
+The view processor map provides automatic processing of mapped views landing on the stage and manual processing where preferred.
 
 ## Extension Installation
 
@@ -28,13 +28,13 @@ You can create your own processor, for example to do property injection without 
 You map either a specific type or a TypeMatcher to the class or instance of processor you want to be used.
 
 ```as3
-viewProcessorMap.map(SomeType).toProcessor(FastInjector);
+viewProcessorMap.map(SomeType).toProcess(FastInjector);
 
-viewProcessorMap.mapMatcher(new TypeMatcher().anyOf(ISpaceShip, IRocket)).toProcessor(SpacecraftSkinner);
+viewProcessorMap.mapMatcher(new TypeMatcher().anyOf(ISpaceShip, IRocket)).toProcess(SpacecraftSkinner);
 
 // you can also use an instance as the processor, in this case, to avoid inspection when doing property injection
 
-viewProcessorMap.map(SomeType).toProcessor( new FastPropertyInjector( { userID:UserID, animationSettings:AnimationSettings } ) );
+viewProcessorMap.map(SomeType).toProcess( new FastPropertyInjector( { userID:UserID, animationSettings:AnimationSettings } ) );
 ```
 
 #### Shortcut method for the most common case: injection by inspection


### PR DESCRIPTION
Changed 'toProcessor' => 'toProcess' function in viewProcessorMap documentation.
Amended spelling.

I do think perhaps you should coin the term 'automagic' for robotlegs though.
